### PR TITLE
Add support for building self-contained presentations and for passing extra variables to pandoc

### DIFF
--- a/example/default.nix
+++ b/example/default.nix
@@ -6,6 +6,6 @@ with pkgs.lib;
   src = ./.;
   name = "example-presentation";
   # reveal version can be changed with revealJS
-  # 3.5.0 is used by default
+  # 3.7.0 is used by default
   revealVersion = "3.4.0";
 }

--- a/example/default.nix
+++ b/example/default.nix
@@ -8,4 +8,7 @@ with pkgs.lib;
   # reveal version can be changed with revealJS
   # 3.7.0 is used by default
   revealVersion = "3.4.0";
+  extraPandocVariables = {
+    theme = "sky";
+  };
 }

--- a/mkPresentation.nix
+++ b/mkPresentation.nix
@@ -5,30 +5,34 @@
 , src
 , name
 , revealVersion ? "3.7.0"
+, selfContained ? false
   # extra dependencies
- ,extraBuildInputs ? []
+, extraBuildInputs ? []
   # assets to include in the result packages, typically examples
- ,assets ? []
+, assets ? []
 }:
 let
   revealJS = fetchTarball "https://github.com/hakimel/reveal.js/archive/${revealVersion}.tar.gz";
 in
 
-pkgs.stdenv.mkDerivation rec {
+with pkgs;
+with pkgs.lib;
+
+stdenv.mkDerivation rec {
   inherit name src;
 
   preferLocalBuild = true;
   allowSubstitutes = false;
 
   # dependencies declaration
-  buildInputs = with pkgs; [ pandoc ] ++ extraBuildInputs;
+  buildInputs = [ pandoc ] ++ extraBuildInputs;
 
   installPhase = ''
     for presentation in $(find . -name "*\.md"); do
       id="$(basename "$presentation" ".md")"
       path="$(dirname "$presentation")"
       mkdir -p "$out/$path"
-      pandoc --to=revealjs --variable revealjs-url=${revealJS} --resource-path="$path" --standalone --out="$out/$path/$id.html" "$presentation"
+      pandoc --to=revealjs --variable revealjs-url=${revealJS} --resource-path="$src/$path" --standalone ${optionalString selfContained "--self-contained"} --out="$out/$path/$id.html" "$presentation"
     done
   '';
 }

--- a/mkPresentation.nix
+++ b/mkPresentation.nix
@@ -8,13 +8,18 @@
 , selfContained ? false
   # extra dependencies
 , extraBuildInputs ? []
+, extraPandocVariables ? {}
 }:
-let
-  revealJS = fetchTarball "https://github.com/hakimel/reveal.js/archive/${revealVersion}.tar.gz";
-in
 
 with pkgs;
 with pkgs.lib;
+
+let
+  revealJS = fetchTarball "https://github.com/hakimel/reveal.js/archive/${revealVersion}.tar.gz";
+
+  extraVars = vars:
+    builtins.concatStringsSep "" (mapAttrsToList (name: value: "--variable " + name + "=" + value) vars);
+in
 
 stdenv.mkDerivation rec {
   inherit name src;
@@ -30,7 +35,7 @@ stdenv.mkDerivation rec {
       id="$(basename "$presentation" ".md")"
       path="$(dirname "$presentation")"
       mkdir -p "$out/$path"
-      pandoc --to=revealjs --variable revealjs-url=${revealJS} --resource-path="$src/$path" --standalone ${optionalString selfContained "--self-contained"} --out="$out/$path/$id.html" "$presentation"
+      pandoc --to=revealjs --variable revealjs-url=${revealJS} ${extraVars extraPandocVariables} --resource-path="$src/$path" --standalone ${optionalString selfContained "--self-contained"} --out="$out/$path/$id.html" "$presentation"
     done
   '';
 }

--- a/mkPresentation.nix
+++ b/mkPresentation.nix
@@ -24,11 +24,11 @@ pkgs.stdenv.mkDerivation rec {
   buildInputs = with pkgs; [ pandoc ] ++ extraBuildInputs;
 
   installPhase = ''
-    mkdir $out
     for presentation in $(find . -name "*\.md"); do
-      id=$(basename $presentation ".md")
-      pandoc -t revealjs -s -o $out/"$id".html "$id".md
+      id="$(basename "$presentation" ".md")"
+      path="$(dirname "$presentation")"
+      mkdir -p "$out/$path"
+      pandoc --to=revealjs --variable revealjs-url=${revealJS} --resource-path="$path" --standalone --out="$out/$path/$id.html" "$presentation"
     done
-    ln -s ${revealJS} $out/reveal.js
   '';
 }

--- a/mkPresentation.nix
+++ b/mkPresentation.nix
@@ -4,7 +4,7 @@
   pkgs
 , src
 , name
-, revealVersion ? "3.5.0"
+, revealVersion ? "3.7.0"
   # extra dependencies
  ,extraBuildInputs ? []
   # assets to include in the result packages, typically examples

--- a/mkPresentation.nix
+++ b/mkPresentation.nix
@@ -8,8 +8,6 @@
 , selfContained ? false
   # extra dependencies
 , extraBuildInputs ? []
-  # assets to include in the result packages, typically examples
-, assets ? []
 }:
 let
   revealJS = fetchTarball "https://github.com/hakimel/reveal.js/archive/${revealVersion}.tar.gz";

--- a/readme.md
+++ b/readme.md
@@ -5,5 +5,9 @@ example slides are in example/presentation.md.
 Can be built by running:
 
 ```sh
-$ nix-build example
+$ nix-build --option build-use-sandbox false example
 ```
+
+NOTE that `--option build-use-sandbox false` is required when using a
+different theme than the default one and when `selfContained` is enabled
+because Pandoc needs network access.


### PR DESCRIPTION
When `selfContained` is false (default), the reveal.js files are now absolute and the reveal.js symlink is removed. This allows the HTML files to reside in any sub-folder without having to maintain relative dependencies.

When `selfContained` is true, the resulting HTML file will have all assets inlined, that includes all reveal.js files as well as any embedded images in the markdown presentation.

Extra variables can be passed in the `extraPandocVariables` set. For example, to use a different theme, pass `extraPandocVariables = { theme = "sky"; };`. Note that when using a reveal.js theme that is not the default theme and has `selfContained` enabled, Pandoc requires network access and this will not work with the sandbox enabled. You must disable the sandbox with `nix-build --option build-use-sandbox false`.